### PR TITLE
add callbacks & event handling for layer visibility and removal

### DIFF
--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -189,6 +189,9 @@ class BaseManipulator(N3dComponent, ABC):
     def visible(self, value: bool):
         self._backend.vispy_visual.visible = value
 
+    def _toggle_visibility(self):
+        self.visible = not self.visible
+
     @property
     def enabled(self) -> bool:
         return self._enabled
@@ -214,6 +217,10 @@ class BaseManipulator(N3dComponent, ABC):
                 self.layer.mouse_drag_callbacks,
                 self._mouse_callback
             )
+
+    def _disable_and_remove(self):
+        self.enabled = False
+        self._backend.vispy_visual.parent.children.remove(self._backend.vispy_visual)
 
     def _on_ndisplay_change(self, event=None):
         if self._viewer.dims.ndisplay == 2:

--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -14,6 +14,10 @@ class LayerManipulator(BaseManipulator):
     def set_layers(self, layer: napari.layers.Layer):
         super().set_layers(layer)
 
+    def _connect_events(self):
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
+
     def _initialize_transform(self):
         # self.origin = self.layer.translate[self.layer._dims_displayed]
         self.origin = np.asarray((0, 0, 0))

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -36,6 +36,8 @@ class PointManipulator(BaseManipulator):
                 self.layer.mouse_drag_callbacks,
                 self.napari_selection_callback_passthrough
             )
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):
         if self.layer is None:

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -18,6 +18,8 @@ class RenderPlaneManipulator(BaseManipulator):
     def _connect_events(self):
         self.layer.plane.events.position.connect(self._update_transform)
         self.layer.plane.events.normal.connect(self._update_transform)
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):
         self.layer.plane.events.position.disconnect(self._update_transform)


### PR DESCRIPTION
I noticed that with the change to having the manipulators not on the layer, when the layer visibility is toggled the manipulator stays visible. Worse yet, when the layer is removed the manipulator persists.
In this PR I added a callback to base_manipulator to toggle visibility and then connect the layer.visible event in the manipulators. Likewise I added a callback to base manipulator to disable and remove the visual, and then I connected the layerlist.removed event to that on the manipulators.
This works nicely for me locally.